### PR TITLE
Add --device=all for gamepad/controller support

### DIFF
--- a/com.bilingify.readest.yml
+++ b/com.bilingify.readest.yml
@@ -12,7 +12,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --socket=pulseaudio
-  - --device=dri
+  - --device=all
   - --share=ipc
   - --share=network
 


### PR DESCRIPTION
## What

Replaces `--device=dri` with `--device=all` in `finish-args` (the latter is a superset and adds `/dev/input` access).

## Why

Readest detects game controllers through the WebKitGTK **Gamepad API** (`navigator.getGamepads()`), backed on Linux by **libmanette/evdev** reading `/dev/input/event*`. The sandbox previously only granted `--device=dri`, so controllers were never detected in the Flathub build.

### Why `--device=all` and not `--device=input`

The narrow `--device=input` only exists in flatpak **1.15.x** (first stable release **1.16.0**, Dec 2024). The Flathub linter (`finish-args-no-required-flatpak`) requires pairing it with `--require-version=`, which would block installation on the many distros still shipping flatpak **1.14.x** (Ubuntu 24.04 LTS, Debian 12, …). Since gamepad support is an optional convenience, `--device=all` is the better trade — it works on every flatpak version and is the linter's recommended backwards-compatible option.

## Testing

```
flatpak run --command=ls com.bilingify.readest -la /dev/input   # event*/js* now visible
```

With a controller connected, press any button (WebKitGTK enumerates gamepads lazily) and page navigation responds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)